### PR TITLE
Add accelerometer motion time out after 15 minutes to factory default

### DIFF
--- a/hexbright_factory.ino
+++ b/hexbright_factory.ino
@@ -2,6 +2,8 @@
 
   Factory firmware for HexBright FLEX 
   v2.4  Dec 6, 2012
+
+  Mod to add auto power off after 15 minutes
   
 */
 
@@ -10,14 +12,26 @@
 
 // Settings
 #define OVERTEMP                340
+// Constants
+#define ACC_ADDRESS             0x4C
+#define ACC_REG_XOUT            0
+#define ACC_REG_YOUT            1
+#define ACC_REG_ZOUT            2
+#define ACC_REG_TILT            3
+#define ACC_REG_INTS            6
+#define ACC_REG_MODE            7
 // Pin assignments
 #define DPIN_RLED_SW            2
 #define DPIN_GLED               5
 #define DPIN_PWR                8
 #define DPIN_DRV_MODE           9
 #define DPIN_DRV_EN             10
+#define DPIN_ACC_INT            3
 #define APIN_TEMP               0
 #define APIN_CHARGE             3
+// Interrupts
+#define INT_SW                  0
+#define INT_ACC                 1
 // Modes
 #define MODE_OFF                0
 #define MODE_LOW                1
@@ -44,12 +58,27 @@ void setup()
   pinMode(DPIN_GLED,     OUTPUT);
   pinMode(DPIN_DRV_MODE, OUTPUT);
   pinMode(DPIN_DRV_EN,   OUTPUT);
+  pinMode(DPIN_ACC_INT,  INPUT);
   digitalWrite(DPIN_DRV_MODE, LOW);
   digitalWrite(DPIN_DRV_EN,   LOW);
+  digitalWrite(DPIN_ACC_INT,  HIGH);
   
   // Initialize serial busses
   Serial.begin(9600);
   Wire.begin();
+
+  // Configure accelerometer
+  byte config[] = {
+    ACC_REG_INTS,  // First register (see next line)
+    0xE4,  // Interrupts: shakes, taps
+    0x00,  // Mode: not enabled yet
+    0x00,  // Sample rate: 120 Hz active
+    0x0F,  // Tap threshold
+    0x10   // Tap debounce samples
+  };
+  Wire.beginTransmission(ACC_ADDRESS);
+  Wire.write(config, sizeof(config));
+  Wire.endTransmission();
   
   btnTime = millis();
   btnDown = digitalRead(DPIN_RLED_SW);
@@ -60,7 +89,7 @@ void setup()
 
 void loop()
 {
-  static unsigned long lastTempTime;
+  static unsigned long lastTempTime, lastModeTime, lastAccTime;
   unsigned long time = millis();
   
   // Check the state of the charge controller
@@ -99,6 +128,28 @@ void loop()
       digitalWrite(DPIN_DRV_MODE, LOW);
 
       mode = MODE_LOW;
+    }
+  }
+
+  // Check if the accelerometer wants to interrupt
+  byte tapped = 0, shaked = 0;
+  if (!digitalRead(DPIN_ACC_INT))
+  {
+    Wire.beginTransmission(ACC_ADDRESS);
+    Wire.write(ACC_REG_TILT);
+    Wire.endTransmission(false);       // End, but do not stop!
+    Wire.requestFrom(ACC_ADDRESS, 1);  // This one stops.
+    byte tilt = Wire.read();
+    
+    if (time-lastAccTime > 500)
+    {
+      lastAccTime = time;
+  
+      tapped = !!(tilt & 0x20);
+      shaked = !!(tilt & 0x80);
+  
+      if (tapped) Serial.println("Tap!");
+      if (shaked) Serial.println("Shake!");
     }
   }
 
@@ -149,10 +200,26 @@ void loop()
       newMode = MODE_OFF;
     break;
   }
-
+  
+  //activity power down
+  if (time-max(lastAccTime,lastModeTime) > 600000UL) { //10 minutes
+    newMode = MODE_OFF;
+  }
+  
   // Do the mode transitions
   if (newMode != mode)
   {
+    lastModeTime = millis();
+ 
+    // Enable or Disable accelerometer
+    byte disable[] = {ACC_REG_MODE, 0x00};  // Mode: standby!
+    byte enable[] = {ACC_REG_MODE, 0x01};  // Mode: active!
+    Wire.beginTransmission(ACC_ADDRESS);
+    if (newMode == MODE_OFF) {
+      Wire.write(disable, sizeof(disable));
+    } else Wire.write(enable, sizeof(enable));
+    Wire.endTransmission();
+
     switch (newMode)
     {
     case MODE_OFF:
@@ -202,5 +269,35 @@ void loop()
     btnDown = newBtnDown;
     delay(50);
   }
+}
+
+void readAccel(char *acc)
+{
+  while (1)
+  {
+    Wire.beginTransmission(ACC_ADDRESS);
+    Wire.write(ACC_REG_XOUT);
+    Wire.endTransmission(false);       // End, but do not stop!
+    Wire.requestFrom(ACC_ADDRESS, 3);  // This one stops.
+
+    for (int i = 0; i < 3; i++)
+    {
+      if (!Wire.available())
+        continue;
+      acc[i] = Wire.read();
+      if (acc[i] & 0x40)  // Indicates failed read; redo!
+        continue;
+      if (acc[i] & 0x20)  // Sign-extend
+        acc[i] |= 0xC0;
+    }
+    break;
+  }
+}
+
+float readAccelAngleXZ()
+{
+  char acc[3];
+  readAccel(acc);
+  return atan2(acc[0], acc[2]);
 }
 


### PR DESCRIPTION
This pull request contains code to leverage the accelerometer to turn the light off after 15 minutes without a tap or shake.  You may consider it useful enough add to the default code.  It only uses the accelerometer when the light is on so as not to drain the battery.
